### PR TITLE
Allow terminating contexts

### DIFF
--- a/zmq2.go
+++ b/zmq2.go
@@ -110,6 +110,27 @@ func SetIoThreads(n int) error {
 	return nil
 }
 
+/*
+Terminates the current and all old contexts.
+
+For linger behavior, see: http://api.zeromq.org/2-2:zmq-term
+*/
+func Term() error {
+	n, err := C.zmq_term(ctx)
+	if n != 0 {
+		return errget(err)
+	}
+
+	for _, oldCtx := range old {
+		n, err := C.zmq_term(oldCtx)
+		if n != 0 {
+			return errget(err)
+		}
+	}
+
+	return nil
+}
+
 //. Sockets
 
 // Specifies the type of a socket, used by NewSocket()


### PR DESCRIPTION
Currently there is no way to wait for pending messages to be sent out before a script quits. This change exposes an API to terminate the ZMQ contexts with zmq_term which will wait if ZMQ_LINGER is set to -1.
